### PR TITLE
Update Nix environment according to cabal file updates

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,15 +1,25 @@
-{ mkDerivation, aeson, base, bytestring, http-api-data, http-client
-, http-types, jose, lens, lib, mtl, servant, servant-server, text
-, time, unordered-containers, wai
+{ mkDerivation, aeson, base, bytestring, cryptonite, hspec
+, hspec-discover, hspec-wai, http-api-data, http-client, http-types
+, jose, lens, lib, mtl, servant, servant-server
+, string-conversions, text, time, transformers
+, unordered-containers, wai, wai-extra
 }:
 mkDerivation {
   pname = "servant-oauth-server";
   version = "0.1.0.0";
   src = ./.;
   libraryHaskellDepends = [
-    aeson base bytestring http-api-data http-client http-types jose
-    lens mtl servant servant-server text time unordered-containers wai
+    aeson base bytestring cryptonite http-api-data http-client
+    http-types jose lens mtl servant servant-server string-conversions
+    text time unordered-containers wai
   ];
+  testHaskellDepends = [
+    aeson base bytestring cryptonite hspec hspec-wai http-api-data
+    http-client http-types jose lens mtl servant
+    servant-server string-conversions text time transformers
+    unordered-containers wai wai-extra
+  ];
+  testToolDepends = [ hspec-discover ];
   homepage = "https://github.com/george-steel/servant-oauth-server#readme";
   description = "OAuth2 bearer token auth and token endpoint for Servant";
   license = lib.licenses.bsd3;

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,7 @@
               pkgs.haskellPackages.implicit-hie
               pkgs.cabal2nix
               pkgs.ormolu
+              pkgs.hlint
 
               # For cabal
               pkgs.pkg-config


### PR DESCRIPTION
Adjust the nix environment:

- Add `hlint`
- Add packages that are new in the cabal project to `default.nix`

This nix environment should contain all Haskell packages besides the right `jose` version (0.9 vs. 0.10) and `lens-aeson`. Unfortunately, `jose_0_10` cannot be tested in our nix environment (tests don't compile). And, the `lens-aeson` version isn't compatible to our usage. So, these will still be built as cabal dependencies.
(We could override or jailBreak. However, I think right now it's good to keep things simple.)

Based on https://github.com/wireapp/servant-oauth-server/pull/5

As I'm on vacation and not always reachable: Please feel free to adjust this PR to your needs. :smile_cat: 
